### PR TITLE
Resolve invalid char encoding with search upgrade

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
     jekyll_pages_api (0.1.5)
       htmlentities (~> 4.3)
       jekyll (>= 2.0, < 4.0)
-    jekyll_pages_api_search (0.3.0)
+    jekyll_pages_api_search (0.3.2)
       jekyll_pages_api (~> 0.1.4)
       sass (~> 3.4)
       therubyracer (~> 0.12.2)


### PR DESCRIPTION
jekyll_pages_api_search v0.3.2 contains 18F/jekyll_pages_api_search#12, which resolves the "invalid character encoding" issue that began to appear on several platforms. The culprit was an en-dash character in the search box code.

@jcscottiii if you don't mind merging this, you can then rebase #24 on it.
