### PR TITLE
Update Gemfile to maintain Windows compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,10 @@ gem 'rouge'
 gem 'go_script'
 
 group :jekyll_plugins do
-  gem 'guides_style_18f'
+  if Gem.win_platform?
+    gem 'wdm', '>= 0.1.0'
+    gem 'guides_style_18f', '0.2.0'
+  else
+    gem 'guides_style_18f'
+  end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,6 @@ gem 'rouge'
 gem 'go_script'
 
 group :jekyll_plugins do
-  if Gem.win_platform?
-    gem 'wdm', '>= 0.1.0'
-    gem 'guides_style_18f', '0.2.0'
-  else
-    gem 'guides_style_18f'
-  end
+  gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+  gem 'guides_style_18f'
 end


### PR DESCRIPTION
The update to [guides_style_18f v0.3.0](https://github.com/18F/guides-style/tree/v0.3.0) introduced a dependency on [jekyll_pages_api_search](https://github.com/18F/jekyll_pages_api_search). That latter gem depends upon [therubyracer](https://rubygems.org/gems/therubyracer), which in turn depends upon [libv8](https://rubygems.org/gems/libv8), a gem that manages the binary distribution of the V8 JavaScript library.

jekyll_pages_api_search uses therubyracer to compile the lunr.js search code and build the index, which is then serialized as `search-index.json`. That gem also includes glue code to load the index asynchronously from the server.

The problem is, on Windows, there is no existing compiled distribution of the libv8 and therubyracer gems. For now, we punt on the issue by locking Windows users to guides_style_18f v0.2.0, the last version that did not depend on jekyll_pages_api_search.

That said, I've managed to successfully compile libv8 and therubyracer on a Windows 8 system, after making a few hacks I plan to contribute upstream. Unfortunately, the resulting therubyracer gem will load and will evaluate JavaScript expressions just fine, but will cause a segfault when the garbage collector kicks in (or so that's my current working theory, based on a test script that will run through to the end before crashing, and then running the script under `gdb`). So I'm tantalizingly close to getting it to work, but this commit will ensure Windows users can still build the site and run the `./go` script commands in the meanwhile.

cc: @afeld @rogeruiz 
