### PR TITLE
Replace should.notify(done) with returned Promises

### DIFF
--- a/solutions/05-middleware/test/middleware-test.js
+++ b/solutions/05-middleware/test/middleware-test.js
@@ -121,8 +121,8 @@ describe('Middleware', function() {
         .returns(Promise.resolve(helpers.ISSUE_URL));
     });
 
-    it('should receive a message and file an issue', function(done) {
-      middleware.execute(context, next, hubotDone)
+    it('should receive a message and file an issue', function() {
+      return middleware.execute(context, next, hubotDone)
         .should.become(helpers.ISSUE_URL).then(function() {
           var matchingRule = new Rule(helpers.baseConfig().rules[2]);
 
@@ -137,7 +137,7 @@ describe('Middleware', function() {
             helpers.logArgs('adding', helpers.baseConfig().successReaction),
             helpers.logArgs('created: ' + helpers.ISSUE_URL)
           ]);
-        }).should.notify(done);
+        });
     });
 
     it('should ignore messages that do not match', function() {
@@ -147,29 +147,28 @@ describe('Middleware', function() {
     });
 
     it('should not file another issue for the same message when ' +
-      'one is in progress', function(done) {
+      'one is in progress', function() {
       var result;
 
       result = middleware.execute(context, next, hubotDone);
-      if (middleware.execute(context, next, hubotDone) !== undefined) {
-        return done(new Error('middleware.execute did not prevent filing a ' +
-          'second issue when one was already in progress'));
-      }
+      expect(middleware.execute(context, next, hubotDone)).to.eql(undefined,
+        'middleware.execute did not prevent filing a second issue ' +
+        'when one was already in progress');
 
-      result.should.become(helpers.ISSUE_URL).then(function() {
+      return result.should.become(helpers.ISSUE_URL).then(function() {
         logger.info.args.should.include.something.that.deep.equals(
           helpers.logArgs('already in progress'));
 
         // Make another call to ensure that the ID is cleaned up. Normally the
         // message will have a successReaction after the first successful
         // request, but we'll test that in another case.
-        middleware.execute(context, next, hubotDone)
-          .should.become(helpers.ISSUE_URL).should.notify(done);
+        return middleware.execute(context, next, hubotDone)
+          .should.become(helpers.ISSUE_URL);
       });
     });
 
     it('should not file another issue for the same message when ' +
-      'one is already filed ', function(done) {
+      'one is already filed ', function() {
       var message = helpers.messageWithReactions();
 
       message.message.reactions.push({
@@ -179,7 +178,7 @@ describe('Middleware', function() {
       });
       slackClient.getReactions.returns(Promise.resolve(message));
 
-      middleware.execute(context, next, hubotDone)
+      return middleware.execute(context, next, hubotDone)
         .should.be.rejectedWith('already processed').then(function() {
           slackClient.getReactions.calledOnce.should.be.true;
           githubClient.fileNewIssue.called.should.be.false;
@@ -187,7 +186,7 @@ describe('Middleware', function() {
           context.response.reply.called.should.be.false;
           logger.info.args.should.include.something.that.deep.equals(
             helpers.logArgs('already processed ' + helpers.PERMALINK));
-        }).should.notify(done);
+        });
     });
 
     checkErrorResponse = function(errorMessage) {
@@ -197,39 +196,39 @@ describe('Middleware', function() {
       logger.error.args.should.have.deep.property('[0][1]', errorMessage);
     };
 
-    it('should receive a message but fail to get reactions', function(done) {
+    it('should receive a message but fail to get reactions', function() {
       var errorMessage = 'failed to get reactions for ' + helpers.PERMALINK +
         ': test failure';
 
       slackClient.getReactions
         .returns(Promise.reject(new Error('test failure')));
 
-      middleware.execute(context, next, hubotDone)
+      return middleware.execute(context, next, hubotDone)
         .should.be.rejectedWith(errorMessage).then(function() {
           slackClient.getReactions.calledOnce.should.be.true;
           githubClient.fileNewIssue.called.should.be.false;
           slackClient.addSuccessReaction.called.should.be.false;
           checkErrorResponse(errorMessage);
-        }).should.notify(done);
+        });
     });
 
-    it('should get reactions but fail to file an issue', function(done) {
+    it('should get reactions but fail to file an issue', function() {
       var errorMessage = 'failed to create a GitHub issue in 18F/handbook: ' +
         'test failure';
 
       githubClient.fileNewIssue
         .returns(Promise.reject(new Error('test failure')));
 
-      middleware.execute(context, next, hubotDone)
+      return middleware.execute(context, next, hubotDone)
         .should.be.rejectedWith(errorMessage).then(function() {
           slackClient.getReactions.calledOnce.should.be.true;
           githubClient.fileNewIssue.calledOnce.should.be.true;
           slackClient.addSuccessReaction.called.should.be.false;
           checkErrorResponse(errorMessage);
-        }).should.notify(done);
+        });
     });
 
-    it('should file an issue but fail to add a reaction', function(done) {
+    it('should file an issue but fail to add a reaction', function() {
       var errorMessage = 'created ' + helpers.ISSUE_URL +
         ' but failed to add ' + helpers.baseConfig().successReaction +
         ': test failure';
@@ -237,13 +236,13 @@ describe('Middleware', function() {
       slackClient.addSuccessReaction
         .returns(Promise.reject(new Error('test failure')));
 
-      middleware.execute(context, next, hubotDone)
+      return middleware.execute(context, next, hubotDone)
         .should.be.rejectedWith(errorMessage).then(function() {
           slackClient.getReactions.calledOnce.should.be.true;
           githubClient.fileNewIssue.calledOnce.should.be.true;
           slackClient.addSuccessReaction.calledOnce.should.be.true;
           checkErrorResponse(errorMessage);
-        }).should.notify(done);
+        });
     });
 
     it('should catch and log unanticipated errors', function() {

--- a/solutions/06-integration/test/integration-test.js
+++ b/solutions/06-integration/test/integration-test.js
@@ -164,8 +164,8 @@ describe('Integration test', function() {
     }
   });
 
-  it('should create a GitHub issue given a valid reaction', function(done) {
-    sendReaction(helpers.REACTION).should.be.fulfilled.then(function() {
+  it('should create a GitHub issue given a valid reaction', function() {
+    return sendReaction(helpers.REACTION).should.be.fulfilled.then(function() {
       room.messages.should.eql([
         ['mbland', 'evergreen_tree'],
         ['hubot', '@mbland created: ' + helpers.ISSUE_URL]
@@ -179,17 +179,17 @@ describe('Integration test', function() {
           'created: ' + helpers.ISSUE_URL
         ]))
       );
-    }).should.notify(done);
+    });
   });
 
-  it('should fail to create a GitHub issue', function(done) {
+  it('should fail to create a GitHub issue', function() {
     var payload = { message: 'test failure' },
         url = '/github/repos/18F/handbook/issues',
         response = apiStubServer.urlsToResponses[url];
 
     response.statusCode = 500;
     response.payload = payload;
-    sendReaction(helpers.REACTION).should.be.fulfilled.then(function() {
+    return sendReaction(helpers.REACTION).should.be.fulfilled.then(function() {
       var errorReply = 'failed to create a GitHub issue in ' +
             '18F/handbook: received 500 response from GitHub API: ' +
             JSON.stringify(payload),
@@ -207,10 +207,10 @@ describe('Integration test', function() {
       ]));
       logMessages.push('ERROR ' + helpers.MESSAGE_ID + ': ' + errorReply);
       logHelper.filteredMessages().should.eql(logMessages);
-    }).should.notify(done);
+    });
   });
 
-  it('should ignore a message receiving an unknown reaction', function(done) {
+  it('should ignore a message receiving an unknown reaction', function() {
     Object.keys(apiStubServer.urlsToResponses).forEach(function(url) {
       var response = apiStubServer.urlsToResponses[url];
 
@@ -218,9 +218,9 @@ describe('Integration test', function() {
       response.payload = { message: 'should not happen' };
     });
 
-    sendReaction('sad-face').should.be.fulfilled.then(function() {
+    return sendReaction('sad-face').should.be.fulfilled.then(function() {
       room.messages.should.eql([['mbland', 'sad-face']]);
       logHelper.filteredMessages().should.eql(initLogMessages());
-    }).should.notify(done);
+    });
   });
 });

--- a/solutions/complete/test/integration-test.js
+++ b/solutions/complete/test/integration-test.js
@@ -164,8 +164,8 @@ describe('Integration test', function() {
     }
   });
 
-  it('should create a GitHub issue given a valid reaction', function(done) {
-    sendReaction(helpers.REACTION).should.be.fulfilled.then(function() {
+  it('should create a GitHub issue given a valid reaction', function() {
+    return sendReaction(helpers.REACTION).should.be.fulfilled.then(function() {
       room.messages.should.eql([
         ['mbland', 'evergreen_tree'],
         ['hubot', '@mbland created: ' + helpers.ISSUE_URL]
@@ -179,17 +179,17 @@ describe('Integration test', function() {
           'created: ' + helpers.ISSUE_URL
         ]))
       );
-    }).should.notify(done);
+    });
   });
 
-  it('should fail to create a GitHub issue', function(done) {
+  it('should fail to create a GitHub issue', function() {
     var payload = { message: 'test failure' },
         url = '/github/repos/18F/handbook/issues',
         response = apiStubServer.urlsToResponses[url];
 
     response.statusCode = 500;
     response.payload = payload;
-    sendReaction(helpers.REACTION).should.be.fulfilled.then(function() {
+    return sendReaction(helpers.REACTION).should.be.fulfilled.then(function() {
       var errorReply = 'failed to create a GitHub issue in ' +
             '18F/handbook: received 500 response from GitHub API: ' +
             JSON.stringify(payload),
@@ -207,10 +207,10 @@ describe('Integration test', function() {
       ]));
       logMessages.push('ERROR ' + helpers.MESSAGE_ID + ': ' + errorReply);
       logHelper.filteredMessages().should.eql(logMessages);
-    }).should.notify(done);
+    });
   });
 
-  it('should ignore a message receiving an unknown reaction', function(done) {
+  it('should ignore a message receiving an unknown reaction', function() {
     Object.keys(apiStubServer.urlsToResponses).forEach(function(url) {
       var response = apiStubServer.urlsToResponses[url];
 
@@ -218,9 +218,9 @@ describe('Integration test', function() {
       response.payload = { message: 'should not happen' };
     });
 
-    sendReaction('sad-face').should.be.fulfilled.then(function() {
+    return sendReaction('sad-face').should.be.fulfilled.then(function() {
       room.messages.should.eql([['mbland', 'sad-face']]);
       logHelper.filteredMessages().should.eql(initLogMessages());
-    }).should.notify(done);
+    });
   });
 });

--- a/solutions/complete/test/middleware-test.js
+++ b/solutions/complete/test/middleware-test.js
@@ -121,8 +121,8 @@ describe('Middleware', function() {
         .returns(Promise.resolve(helpers.ISSUE_URL));
     });
 
-    it('should receive a message and file an issue', function(done) {
-      middleware.execute(context, next, hubotDone)
+    it('should receive a message and file an issue', function() {
+      return middleware.execute(context, next, hubotDone)
         .should.become(helpers.ISSUE_URL).then(function() {
           var matchingRule = new Rule(helpers.baseConfig().rules[2]);
 
@@ -137,7 +137,7 @@ describe('Middleware', function() {
             helpers.logArgs('adding', helpers.baseConfig().successReaction),
             helpers.logArgs('created: ' + helpers.ISSUE_URL)
           ]);
-        }).should.notify(done);
+        });
     });
 
     it('should ignore messages that do not match', function() {
@@ -147,29 +147,28 @@ describe('Middleware', function() {
     });
 
     it('should not file another issue for the same message when ' +
-      'one is in progress', function(done) {
+      'one is in progress', function() {
       var result;
 
       result = middleware.execute(context, next, hubotDone);
-      if (middleware.execute(context, next, hubotDone) !== undefined) {
-        return done(new Error('middleware.execute did not prevent filing a ' +
-          'second issue when one was already in progress'));
-      }
+      expect(middleware.execute(context, next, hubotDone)).to.eql(undefined,
+        'middleware.execute did not prevent filing a second issue ' +
+        'when one was already in progress');
 
-      result.should.become(helpers.ISSUE_URL).then(function() {
+      return result.should.become(helpers.ISSUE_URL).then(function() {
         logger.info.args.should.include.something.that.deep.equals(
           helpers.logArgs('already in progress'));
 
         // Make another call to ensure that the ID is cleaned up. Normally the
         // message will have a successReaction after the first successful
         // request, but we'll test that in another case.
-        middleware.execute(context, next, hubotDone)
-          .should.become(helpers.ISSUE_URL).should.notify(done);
+        return middleware.execute(context, next, hubotDone)
+          .should.become(helpers.ISSUE_URL);
       });
     });
 
     it('should not file another issue for the same message when ' +
-      'one is already filed ', function(done) {
+      'one is already filed ', function() {
       var message = helpers.messageWithReactions();
 
       message.message.reactions.push({
@@ -179,7 +178,7 @@ describe('Middleware', function() {
       });
       slackClient.getReactions.returns(Promise.resolve(message));
 
-      middleware.execute(context, next, hubotDone)
+      return middleware.execute(context, next, hubotDone)
         .should.be.rejectedWith('already processed').then(function() {
           slackClient.getReactions.calledOnce.should.be.true;
           githubClient.fileNewIssue.called.should.be.false;
@@ -187,7 +186,7 @@ describe('Middleware', function() {
           context.response.reply.called.should.be.false;
           logger.info.args.should.include.something.that.deep.equals(
             helpers.logArgs('already processed ' + helpers.PERMALINK));
-        }).should.notify(done);
+        });
     });
 
     checkErrorResponse = function(errorMessage) {
@@ -197,39 +196,39 @@ describe('Middleware', function() {
       logger.error.args.should.have.deep.property('[0][1]', errorMessage);
     };
 
-    it('should receive a message but fail to get reactions', function(done) {
+    it('should receive a message but fail to get reactions', function() {
       var errorMessage = 'failed to get reactions for ' + helpers.PERMALINK +
         ': test failure';
 
       slackClient.getReactions
         .returns(Promise.reject(new Error('test failure')));
 
-      middleware.execute(context, next, hubotDone)
+      return middleware.execute(context, next, hubotDone)
         .should.be.rejectedWith(errorMessage).then(function() {
           slackClient.getReactions.calledOnce.should.be.true;
           githubClient.fileNewIssue.called.should.be.false;
           slackClient.addSuccessReaction.called.should.be.false;
           checkErrorResponse(errorMessage);
-        }).should.notify(done);
+        });
     });
 
-    it('should get reactions but fail to file an issue', function(done) {
+    it('should get reactions but fail to file an issue', function() {
       var errorMessage = 'failed to create a GitHub issue in 18F/handbook: ' +
         'test failure';
 
       githubClient.fileNewIssue
         .returns(Promise.reject(new Error('test failure')));
 
-      middleware.execute(context, next, hubotDone)
+      return middleware.execute(context, next, hubotDone)
         .should.be.rejectedWith(errorMessage).then(function() {
           slackClient.getReactions.calledOnce.should.be.true;
           githubClient.fileNewIssue.calledOnce.should.be.true;
           slackClient.addSuccessReaction.called.should.be.false;
           checkErrorResponse(errorMessage);
-        }).should.notify(done);
+        });
     });
 
-    it('should file an issue but fail to add a reaction', function(done) {
+    it('should file an issue but fail to add a reaction', function() {
       var errorMessage = 'created ' + helpers.ISSUE_URL +
         ' but failed to add ' + helpers.baseConfig().successReaction +
         ': test failure';
@@ -237,13 +236,13 @@ describe('Middleware', function() {
       slackClient.addSuccessReaction
         .returns(Promise.reject(new Error('test failure')));
 
-      middleware.execute(context, next, hubotDone)
+      return middleware.execute(context, next, hubotDone)
         .should.be.rejectedWith(errorMessage).then(function() {
           slackClient.getReactions.calledOnce.should.be.true;
           githubClient.fileNewIssue.calledOnce.should.be.true;
           slackClient.addSuccessReaction.calledOnce.should.be.true;
           checkErrorResponse(errorMessage);
-        }).should.notify(done);
+        });
     });
 
     it('should catch and log unanticipated errors', function() {


### PR DESCRIPTION
Corresponds to 18F/hubot-slack-github-issues#49.

I'd originally used `should.notify(done)` based on the advice from https://www.npmjs.com/package/chai-as-promised#working-with-non-promisefriendly-test-runners. However, returning the generated Promise is sufficient for Mocha.

I'll update the corresponding text in a future PR.

cc: @catherinedevlin 
