### PR TITLE
Set timeout of 5000ms for smoke tests on Docker

### DIFF
--- a/solutions/07-system/test/smoke-test.js
+++ b/solutions/07-system/test/smoke-test.js
@@ -15,6 +15,8 @@ var FAILURE_MESSAGE = scriptName + ': receiveMiddleware registration failed: ';
 describe('Smoke test', function() {
   var checkHubot;
 
+  this.timeout(5000);
+
   beforeEach(function() {
     delete process.env.HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH;
   });

--- a/solutions/complete/test/smoke-test.js
+++ b/solutions/complete/test/smoke-test.js
@@ -15,6 +15,8 @@ var FAILURE_MESSAGE = scriptName + ': receiveMiddleware registration failed: ';
 describe('Smoke test', function() {
   var checkHubot;
 
+  this.timeout(5000);
+
   beforeEach(function() {
     delete process.env.HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH;
   });


### PR DESCRIPTION
Closes #30.

Somehow it takes the smoke tests a little longer to run on Docker. This addresses the issue without any side effects on other systems.

cc: @jcscottiii 
